### PR TITLE
Remove duplicate 'Cassette' app

### DIFF
--- a/src/apps.ts
+++ b/src/apps.ts
@@ -949,11 +949,6 @@ const APP_MAP: Record<string, App> = {
     desc: "A Retro Engine v5 launcher",
     lang: Lang.Python,
   },
-  "io.github.Rirusha.Cassette": {
-    name: "Cassette",
-    desc: "Unofficial Yandex.Music client",
-    lang: Lang.Vala,
-  },
   "io.github.nokse22.minitext": {
     name: "Mini Text",
     desc: "Ephemeral scratch pad",


### PR DESCRIPTION
I noticed that there were two Cassette apps when browsing the site and both resolve to the same page (https://flathub.org/apps/space.rirusha.Cassette). 

I removed the entry that has a differing package name (`io.github.Rirusha.Cassette`)