### PR TITLE
Update programming language and name of Pins app

### DIFF
--- a/src/apps.ts
+++ b/src/apps.ts
@@ -840,7 +840,7 @@ const APP_MAP: Record<string, App> = {
     lang: Lang.Python,
   },
   "io.github.fabrialberio.pinapp": {
-    name: "PinApp",
+    name: "Pins",
     desc: "Create and edit application shortcuts",
     lang: Lang.Python,
   },

--- a/src/apps.ts
+++ b/src/apps.ts
@@ -842,7 +842,7 @@ const APP_MAP: Record<string, App> = {
   "io.github.fabrialberio.pinapp": {
     name: "Pins",
     desc: "Create and edit application shortcuts",
-    lang: Lang.Python,
+    lang: Lang.C,
   },
   "it.mijorus.whisper": {
     name: "Whisper",


### PR DESCRIPTION
The app _PinApp_ is shown as written in _Python_, but it is actually written in _C_. As you can see on _Github_: https://github.com/fabrialberio/Pins

Moreover, I think it should rather be called `Pins` instead of `PinsApp`, as it is named like that on _Flathub_ and _Github_.