### PR TITLE
Remove Forgetpass app

### DIFF
--- a/src/apps.ts
+++ b/src/apps.ts
@@ -844,11 +844,6 @@ const APP_MAP: Record<string, App> = {
     desc: "Listen to your mic",
     lang: Lang.Python,
   },
-  "com.github.alexkdeveloper.forgetpass": {
-    name: "Forgetpass",
-    desc: "Simple password generator for websites",
-    lang: Lang.Vala,
-  },
   "de.schmidhuberj.tubefeeder": {
     name: "Pipeline",
     desc: "Follow video creators",


### PR DESCRIPTION
This application is no longer available on Flathub and is no longer maintained.