### PR TITLE
Remove Furtherance (now based on iced.rs)

### DIFF
--- a/src/apps.ts
+++ b/src/apps.ts
@@ -549,11 +549,6 @@ const APP_MAP: Record<string, App> = {
     desc: "Time games of over-the-board chess",
     lang: Lang.Python,
   },
-  "com.lakoliu.Furtherance": {
-    name: "Furtherance",
-    desc: "Track your time without being tracked",
-    lang: Lang.Rust,
-  },
   "io.github.lainsce.Khronos": {
     name: "Khronos",
     desc: "Log the time it took to do tasks",


### PR DESCRIPTION
Furtherance [1.8.3](https://github.com/unobserved-io/Furtherance/releases/tag/v1.8.3) was the last libadwaita-based release and the app switched to the iced.rs UI framework with the [24.10](https://github.com/unobserved-io/Furtherance/releases/tag/24.10.0) release.