### PR TITLE
Rename Decibels to Audio Player

### DIFF
--- a/src/apps.ts
+++ b/src/apps.ts
@@ -365,7 +365,7 @@ const APP_MAP: Record<string, App> = {
     lang: Lang.Rust,
   },
   "org.gnome.Decibels": {
-    name: "Decibels",
+    name: "Audio Player",
     desc: "Play audio files",
     lang: Lang.JavaScript,
   },


### PR DESCRIPTION
See:
https://gitlab.gnome.org/GNOME/decibels/-/commit/a98161f300560f3df12b37242f34ee4f8b0ee307
https://flathub.org/apps/org.gnome.Decibels