### PR TITLE
Add Lights Off, Mines, Nibbles, GNOME Robots and Swell Foop

### DIFF
--- a/src/apps.ts
+++ b/src/apps.ts
@@ -1649,6 +1649,31 @@ const APP_MAP: Record<string, App> = {
     desc: "A simple, modern sound recorder for GNOME",
     lang: Lang.JavaScript,
   },
+  "org.gnome.LightsOff": {
+    name: "Lights Off",
+    desc: "Turn off all the lights",
+    lang: Lang.Vala,
+  },
+  "org.gnome.Mines": {
+    name: "Mines",
+    desc: "Clear hidden mines from a minefield",
+    lang: Lang.Vala,
+  },
+  "org.gnome.Nibbles": {
+    name: "Nibbles",
+    desc: "Guide a worm around a maze",
+    lang: Lang.Vala,
+  },
+  "org.gnome.Robots": {
+    name: "GNOME Robots",
+    desc: "Avoid the robots and make them crash into each other",
+    lang: Lang.Rust,
+  },
+  "org.gnome.SwellFoop": {
+    name: "Swell Foop",
+    desc: "Clear the screen by removing groups of colored and shaped tiles",
+    lang: Lang.Vala,
+  },
 };
 
 export default Object.entries(APP_MAP)


### PR DESCRIPTION
These games were ported to GTK4+LibAdwaita recently.

Lights Off:
- https://flathub.org/apps/org.gnome.LightsOff
- https://gitlab.gnome.org/GNOME/lightsoff

Nibbles:
- https://flathub.org/apps/org.gnome.Nibbles
- https://gitlab.gnome.org/GNOME/gnome-nibbles

Mines:
- https://flathub.org/apps/org.gnome.Mines
- https://gitlab.gnome.org/GNOME/gnome-mines

GNOME Robots:
- https://flathub.org/apps/org.gnome.Robots
- https://gitlab.gnome.org/GNOME/gnome-robots

Swell Foop:
- https://flathub.org/apps/org.gnome.SwellFoop
- https://gitlab.gnome.org/GNOME/swell-foop