### PR TITLE
Add Drum Machine

### DIFF
--- a/src/apps.ts
+++ b/src/apps.ts
@@ -1679,6 +1679,11 @@ const APP_MAP: Record<string, App> = {
     desc: "Application chooser",
     lang: Lang.JavaScript,
   },
+  "io.github.revisto.drum-machine": {
+    name: "Drum Machine",
+    desc: "Create and play drum beats",
+    lang: Lang.Python,
+  },
 };
 
 export default Object.entries(APP_MAP)


### PR DESCRIPTION
A drum machine application, built with Python, GTK4, libadwaita, and Pygame.
Already part of GNOME Circle.

Source:
https://flathub.org/apps/io.github.revisto.drum-machine
https://github.com/revisto/drum-machine