### PR TITLE
Add Ignition app

### DIFF
--- a/src/apps.ts
+++ b/src/apps.ts
@@ -1690,6 +1690,11 @@ const APP_MAP: Record<string, App> = {
     desc: "Manage Distrobox containers",
     lang: Lang.Rust,
   },
+    "io.github.flattool.Ignition": {
+    name: "Ignition",
+    desc: "Manage startup apps and scripts",
+    lang: Lang.TypeScript,
+  },
 };
 
 export default Object.entries(APP_MAP)

--- a/src/apps.ts
+++ b/src/apps.ts
@@ -15,6 +15,7 @@ export enum Lang {
   Python = "Python",
   Rust = "Rust",
   Swift = "Swift",
+  TypeScript = "TypeScript",
   Vala = "Vala",
 }
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -55,6 +55,7 @@ import "../styles/global.css";
                     app.lang === Lang.C || app.lang === Lang.Crystal,
                   "bg-pink-100 text-pink-900": app.lang === Lang.CPlusPlus,
                   "bg-yellow-100 text-yellow-900": app.lang === Lang.JavaScript,
+                  "bg-blue-200 text-blue-900": app.lang === Lang.TypeScript,
                 }}
               >
                 {app.lang}


### PR DESCRIPTION
Ignition is a minimal app for editing autostart entries on Freedesktop-compliant Linux distributions.
Also added `TypeScript` to the `Lang` enum.

Source:
https://flathub.org/apps/io.github.flattool.Ignition
https://github.com/flattool/ignition