### PR TITLE
Removing Pomodoro and Radio for not being available on flathub anymore

### DIFF
--- a/src/apps.ts
+++ b/src/apps.ts
@@ -860,11 +860,6 @@ const APP_MAP: Record<string, App> = {
     desc: "Convert between currencies",
     lang: Lang.Python,
   },
-  "io.gitlab.idevecore.Pomodoro": {
-    name: "Pomodoro",
-    desc: "Pomodoro is a productivity-focused timer",
-    lang: Lang.JavaScript,
-  },
   "io.github.amit9838.mousam": {
     name: "Mousam",
     desc: "Weather at a glance",
@@ -1354,11 +1349,6 @@ const APP_MAP: Record<string, App> = {
     name: "SkyTemple Randomizer",
     desc: "Randomizer for Pokémon Mystery Dungeon Explorers of Sky",
     lang: Lang.Python,
-  },
-  "io.github.alexkdeveloper.radio": {
-    name: "Radio",
-    desc: "A simple radio with stations from the website radio-browser.info",
-    lang: Lang.Vala,
   },
   "com.adrienplazas.Metronome": {
     name: "Metronome",


### PR DESCRIPTION
According to these PRs:
https://github.com/flathub/io.gitlab.idevecore.Pomodoro/pull/6
https://github.com/flathub/io.github.alexkdeveloper.radio/pull/32

Both Pomodoro and Radio are now end of life and are not available on Flathub anymore.

Dead flathub links:
https://flathub.org/apps/io.gitlab.idevecore.Pomodoro
https://flathub.org/apps/io.github.alexkdeveloper.radio