### PR TITLE
Add Scriptorium app

### DIFF
--- a/src/apps.ts
+++ b/src/apps.ts
@@ -1695,6 +1695,11 @@ const APP_MAP: Record<string, App> = {
     desc: "Quickly edit screenshots to put them better in context",
     lang: Lang.Python,
   },
+  "io.github.cgueret.Scriptorium": {
+    name: "Scriptorium",
+    desc: "An all in one book editing tool for Gnome",
+    lang: Lang.Python,
+  },
 };
 
 export default Object.entries(APP_MAP)

--- a/src/apps.ts
+++ b/src/apps.ts
@@ -1697,7 +1697,7 @@ const APP_MAP: Record<string, App> = {
   },
   "io.github.cgueret.Scriptorium": {
     name: "Scriptorium",
-    desc: "An all in one book editing tool for Gnome",
+    desc: "An all in one book editing tool for GNOME",
     lang: Lang.Python,
   },
 };


### PR DESCRIPTION
Scriptorium is an all in one book editing tool for Gnome.

Source:
https://flathub.org/apps/io.github.cgueret.Scriptorium
https://github.com/cgueret/Scriptorium