### PR TITLE
Add Tuner and Pigment app

### DIFF
--- a/src/apps.ts
+++ b/src/apps.ts
@@ -1710,6 +1710,11 @@ const APP_MAP: Record<string, App> = {
     desc: "A simple multiplication puzzle game",
     lang: Lang.Vala,
   },
+  "org.altlinux.Tuner": {
+    name: "Tuner",
+    desc: "Extensible control center for GNOME",
+    lang: Lang.Vala,
+  },
 };
 
 export default Object.entries(APP_MAP)

--- a/src/apps.ts
+++ b/src/apps.ts
@@ -1715,6 +1715,11 @@ const APP_MAP: Record<string, App> = {
     desc: "Extensible control center for GNOME",
     lang: Lang.Vala,
   },
+  "com.jeffser.Pigment": {
+    name: "Pigment",
+    desc: "Get color palettes from images",
+    lang: Lang.Python,
+  },
 };
 
 export default Object.entries(APP_MAP)


### PR DESCRIPTION
Tuner is the home for your additional system settings, components, applications, and whatever else you want!
\* It's similar to Refine app
https://flathub.org/apps/org.altlinux.Tuner
https://altlinux.space/alt-gnome/Tuner

Pigment allows you to quickly extract a color palette from any image offline.
https://flathub.org/apps/com.jeffser.Pigment
https://github.com/Jeffser/Pigment