### PR TITLE
Remove Doggo app

### DIFF
--- a/src/lib/apps.ts
+++ b/src/lib/apps.ts
@@ -894,11 +894,6 @@ const APP_MAP: Record<string, App> = {
 		desc: 'Downloads and applies wallpapers',
 		lang: Lang.Rust
 	},
-	'app.drey.Doggo': {
-		name: 'Doggo',
-		desc: 'Clicker and chance game',
-		lang: Lang.C
-	},
 	'com.github.tenderowl.frog': {
 		name: 'Frog',
 		desc: 'Extract text from images',


### PR DESCRIPTION
The project is archived, and was removed from Flathub.

https://flathub.org/apps/app.drey.Doggo