### PR TITLE
Use GNOME Circle'ds website favicon as GNOME Circle marker

### DIFF
--- a/src/lib/components/app-card.svelte
+++ b/src/lib/components/app-card.svelte
@@ -53,7 +53,7 @@
 									</Tooltip.Root>
 								</Tooltip.Provider>
 							{/if}
-							<Badge variant="secondary" class="h-5 rounded-full px-1.5 text-[10px]"
+							<Badge variant="secondary" class="h-5 rounded-full px-1.5 text-xs"
 								>{app.lang.target}</Badge
 							>
 						</div>

--- a/src/lib/components/app-card.svelte
+++ b/src/lib/components/app-card.svelte
@@ -42,7 +42,7 @@
 									<Tooltip.Root>
 										<Tooltip.Trigger>
 											<img
-												src="https://circle.gnome.org/assets/ecosystem.svg"
+												src="https://circle.gnome.org/assets/favicon.svg"
 												alt="GNOME Circle"
 												class="size-5"
 											/>


### PR DESCRIPTION
It's a bit better recognizable at this small size.