### PR TITLE
chore: rename Word2ipa to Word2IPA

### DIFF
--- a/src/lib/apps.ts
+++ b/src/lib/apps.ts
@@ -2302,7 +2302,7 @@ const APP_MAP: Record<string, App> = {
 		lang: Lang.Rust
 	},
 	'io.github.mohfy.word2ipa': {
-		name: 'Word2ipa',
+		name: 'Word2IPA',
 		desc: 'Turn words into their true sounds',
 		lang: Lang.Python
 	}


### PR DESCRIPTION
The application name was updated to Word2IPA on upstream Flathub.